### PR TITLE
❄️  Move pre-commit hooks to nix

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,4 @@
+{
+  "default": true,
+  "code-block-style": {"style": "fenced"},
+}

--- a/.pymarkdown.json
+++ b/.pymarkdown.json
@@ -1,7 +1,0 @@
-{
-  "plugins": {
-    "md046": {
-      "enabled": false
-    }
-  }
-}

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -5,13 +5,15 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "bazel_skylib",
+    sha256 = "af87959afe497dc8dfd4c6cb66e1279cb98ccc84284619ebfec27d9c09a903de",
     urls = [
         "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.2.0/bazel-skylib-1.2.0.tar.gz",
         "https://github.com/bazelbuild/bazel-skylib/releases/download/1.2.0/bazel-skylib-1.2.0.tar.gz",
     ],
-    sha256 = "af87959afe497dc8dfd4c6cb66e1279cb98ccc84284619ebfec27d9c09a903de",
 )
+
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
 bazel_skylib_workspace()
 
 http_archive(

--- a/docs/guides/cuda_and_hip.md
+++ b/docs/guides/cuda_and_hip.md
@@ -7,9 +7,11 @@ At the moment `rules_ll` supports Nvidia and AMD GPUs.
 
 You can find examples at [`rules_ll/examples`](https://github.com/eomii/rules_ll/tree/main/examples).
 
+<!-- markdownlint-disable code-block-style -->
 !!! warning
 
     This feature is still under heavy development. APIs will frequently change.
+<!-- markdownlint-enable code-block-style -->
 
 ## Prerequisites
 

--- a/docs/guides/modules.md
+++ b/docs/guides/modules.md
@@ -5,6 +5,7 @@ use them if you can.
 
 You can find full examples at [`rules_ll/examples`](https://github.com/eomii/rules_ll/tree/main/examples).
 
+<!-- markdownlint-disable code-block-style -->
 !!! note
 
     `rules_ll` has no builtin support for Clang modules. This feature precedes C++
@@ -15,6 +16,7 @@ You can find full examples at [`rules_ll/examples`](https://github.com/eomii/rul
 
     Due to a bug in `clang-tidy` you have to silence
     `readability-redundant-declaration` when using modules.
+<!-- markdownlint-enable code-block-style -->
 
 ## Basic usage
 

--- a/docs/setup/setup.md
+++ b/docs/setup/setup.md
@@ -2,6 +2,7 @@
 
 This guide explains how to set up `rules_ll`.
 
+<!-- markdownlint-disable code-block-style -->
 ??? "System requirements"
 
     `rules_ll` makes heavy use of upstream dependencies. Staying upstream
@@ -34,6 +35,7 @@ This guide explains how to set up `rules_ll`.
       `5.2`. This applies to 10xx series GPUs and up, and some `9xx` series
       GPUs. You can find a list of compute capabilities at
       <https://developer.nvidia.com/cuda-gpus>.
+<!-- markdownlint-enable code-block-style -->
 
 1. Install the [nix package manager](https://nixos.org/download.html) and enable
    [flakes](https://nixos.wiki/wiki/Flakes).
@@ -44,9 +46,9 @@ This guide explains how to set up `rules_ll`.
     nix develop github:eomii/rules_ll
     ```
 
-    To use CUDA packages and toolchains, make sure to read the [CUDA license](
-    https://docs.nvidia.com/cuda/eula/index.html) and use the unfree `rules_ll`
-    shell:
+    To use CUDA packages and toolchains, make sure to read the [CUDA
+    license](https://docs.nvidia.com/cuda/eula/index.html) and use the unfree
+    `rules_ll` shell:
 
     ```bash
     nix develop github:eomii/rules_ll#unfree

--- a/flake.lock
+++ b/flake.lock
@@ -38,6 +38,22 @@
         "type": "github"
       }
     },
+    "flake-compat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "locked": {
         "lastModified": 1667395993,
@@ -55,11 +71,26 @@
     },
     "flake-utils_2": {
       "locked": {
-        "lastModified": 1676283394,
-        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
+        "lastModified": 1678901627,
+        "narHash": "sha256-U02riOqrKKzwjsxc/400XnElV+UtPUQWpANPlyazjH0=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
+        "rev": "93a2b84fc4b70d9e089d029deacc3583435c2ed6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_3": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
         "type": "github"
       },
       "original": {
@@ -73,6 +104,27 @@
         "nixpkgs": [
           "devenv",
           "pre-commit-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1660459072,
+        "narHash": "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "gitignore_2": {
+      "inputs": {
+        "nixpkgs": [
+          "pre-commit-hooks-nix",
           "nixpkgs"
         ]
       },
@@ -178,17 +230,49 @@
         "type": "github"
       }
     },
+    "nixpkgs-stable_2": {
+      "locked": {
+        "lastModified": 1673800717,
+        "narHash": "sha256-SFHraUqLSu5cC6IxTprex/nTsI81ZQAtDvlBvGDWfnA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2f9fd351ec37f5d479556cd48be4ca340da59b8f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-22.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1678725452,
-        "narHash": "sha256-oRPz1nYlNCe9Ogq/EAgUGZUL1//j2gFqBc0FkFWXSp0=",
+        "lastModified": 1678970889,
+        "narHash": "sha256-Ub1SIPHSkN9wH9+onv+2scbZvfJFQkQG07oCs+0ctYc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f834dfad8f6c63e643da252ca43a7d15775d3734",
+        "rev": "3f27a6e65fedd177ddecbf2146c128ab4f458ef1",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1671271357,
+        "narHash": "sha256-xRJdLbWK4v2SewmSStYrcLa0YGJpleufl44A19XSW8k=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "40f79f003b6377bd2f4ed4027dde1f8f922995dd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -221,11 +305,34 @@
         "type": "github"
       }
     },
+    "pre-commit-hooks-nix": {
+      "inputs": {
+        "flake-compat": "flake-compat_2",
+        "flake-utils": "flake-utils_3",
+        "gitignore": "gitignore_2",
+        "nixpkgs": "nixpkgs_3",
+        "nixpkgs-stable": "nixpkgs-stable_2"
+      },
+      "locked": {
+        "lastModified": 1678376203,
+        "narHash": "sha256-3tyYGyC8h7fBwncLZy5nCUjTJPrHbmNwp47LlNLOHSM=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "1a20b9708962096ec2481eeb2ddca29ed747770a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "devenv": "devenv",
         "flake-utils": "flake-utils_2",
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": "nixpkgs_2",
+        "pre-commit-hooks-nix": "pre-commit-hooks-nix"
       }
     }
   },

--- a/ll/BUILD.bazel
+++ b/ll/BUILD.bazel
@@ -1,3 +1,5 @@
+"Central build file for the docs, platforms, toolchains and config settings."
+
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 load("@stardoc//stardoc:stardoc.bzl", "stardoc")

--- a/pre-commit-hooks.nix
+++ b/pre-commit-hooks.nix
@@ -1,0 +1,89 @@
+{ pkgs, ... }:
+{
+  # Default hooks
+  trailing-whitespace-fixer = {
+    enable = true;
+    name = "trailing-whitespace";
+    description = "Remove trailing whitespace";
+    entry = "${pkgs.python311Packages.pre-commit-hooks}/bin/trailing-whitespace-fixer";
+    excludes = [ "^patches/" ];
+    types = [ "text" ];
+  };
+  end-of-file-fixer = {
+    enable = true;
+    name = "end-of-file-fixer";
+    description = "Remove trailing whitespace";
+    entry = "${pkgs.python311Packages.pre-commit-hooks}/bin/end-of-file-fixer";
+    excludes = [ "^patches/" "png" ];
+    types = [ "text" ];
+  };
+  fix-byte-order-marker = {
+    enable = true;
+    name = "fix-byte-order-marker";
+    entry = "${pkgs.python311Packages.pre-commit-hooks}/bin/fix-byte-order-marker";
+    types = [ "text" ];
+  };
+  mixed-line-ending = {
+    enable = true;
+    name = "mixed-line-ending";
+    entry = "${pkgs.python311Packages.pre-commit-hooks}/bin/mixed-line-ending";
+    excludes = [ "png" ];
+    types = [ "text" ];
+  };
+  check-case-conflict = {
+    enable = true;
+    name = "check-case-conflict";
+    entry = "${pkgs.python311Packages.pre-commit-hooks}/bin/check-case-conflict";
+    types = [ "text" ];
+  };
+  detect-private-key = {
+    enable = true;
+    name = "detect-private-key";
+    entry = "${pkgs.python311Packages.pre-commit-hooks}/bin/detect-private-key";
+    types = [ "text" ];
+  };
+
+  # Starlark
+  bazel-buildifier-format = {
+    enable = true;
+    name = "buildifier format";
+    description = "Format Starlark";
+    entry = "${pkgs.bazel-buildtools}/bin/buildifier";
+    types = [ "bazel" ];
+  };
+  bazel-buildifier-lint = {
+    enable = true;
+    name = "buildifier lint";
+    description = "Lint Starlark";
+    entry = "${pkgs.bazel-buildtools}/bin/buildifier -lint=warn";
+    types = [ "bazel" ];
+  };
+
+  # YAML
+  yamllint.enable = true;
+
+  # Bash/Shell
+  shellcheck = {
+    enable = true;
+    excludes = [ "png" ];
+  };
+
+  # Nix
+  nixpkgs-fmt.enable = true;
+
+  # C++
+  clang-format15 = {
+    enable = true;
+    name = "clang-format";
+    types_or = [ "c" "c++" ];
+    entry = "${pkgs.llvmPackages_15.libclang}/bin/clang-format";
+    excludes = [ "^(docs/|^llvm-project-overlay/)" ];
+  };
+
+  # Markdown
+  markdownlint = {
+    enable = true;
+    excludes = [ "^(docs/reference/|docs/rules/)" ];
+    types = [ "markdown" ];
+  };
+}

--- a/third-party-overlays/comgr.BUILD.bazel
+++ b/third-party-overlays/comgr.BUILD.bazel
@@ -1,6 +1,7 @@
-load("@rules_ll//ll:defs.bzl", "ll_binary", "ll_library")
+"Build file for ROCm-CompilerSupport."
+
+load("@rules_ll//ll:defs.bzl", "ll_library")
 load("@rules_ll//third-party-overlays:defs.bzl", "opencl_pch")
-load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 

--- a/third-party-overlays/hip.BUILD.bazel
+++ b/third-party-overlays/hip.BUILD.bazel
@@ -1,4 +1,6 @@
-load("@rules_ll//ll:defs.bzl", "ll_binary", "ll_library", "OFFLOAD_ALL_AMDGPU")
+"Build file for HIP."
+
+load("@rules_ll//ll:defs.bzl", "OFFLOAD_ALL_AMDGPU", "ll_binary", "ll_library")
 
 # Target for the toolchains.
 filegroup(

--- a/third-party-overlays/hipamd.BUILD.bazel
+++ b/third-party-overlays/hipamd.BUILD.bazel
@@ -1,3 +1,5 @@
+"Build file for hipamd."
+
 load("@rules_ll//ll:defs.bzl", "ll_library")
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 load("@rules_ll//third-party-overlays:rocclr_config.bzl", "ROCCLR_DEFINES")
@@ -69,7 +71,7 @@ ll_library(
         "@rocr//:libhsa-runtime64",
     ] + select({
         "@roct//:shared": ["@roct//:libhsakmt"],
-        "//conditions:default": []
+        "//conditions:default": [],
     }),
     defines = ROCCLR_DEFINES + [
         "HIP_VERSION_MAJOR=5",
@@ -79,7 +81,6 @@ ll_library(
         'HIP_VERSION_GITHASH="0000"',
         'HIP_VERSION_BUILD_NAME="rules_hip_custom_build_name_string"',
         "HIP_VERSION_BUILD_ID=0",
-
         "__HIP_PLATFORM_AMD__",
     ],
     compile_flags = [
@@ -109,5 +110,5 @@ ll_library(
         "//conditions:default": [
             "-lelf",
         ],
-    })
+    }),
 )

--- a/third-party-overlays/rocclr.BUILD.bazel
+++ b/third-party-overlays/rocclr.BUILD.bazel
@@ -1,3 +1,5 @@
+"Build file for ROCclr."
+
 load("@rules_ll//ll:defs.bzl", "ll_library")
 load("@rules_ll//third-party-overlays:rocclr_config.bzl", "ROCCLR_DEFINES")
 

--- a/third-party-overlays/rocm-device-libs.BUILD.bazel
+++ b/third-party-overlays/rocm-device-libs.BUILD.bazel
@@ -1,3 +1,5 @@
+"Build file for the ROCm-Device-Libs."
+
 load("@rules_ll//ll:defs.bzl", "ll_binary")
 load("@rules_ll//third-party-overlays:defs.bzl", "opencl_bitcode_library")
 

--- a/third-party-overlays/rocm-opencl-runtime.BUILD.bazel
+++ b/third-party-overlays/rocm-opencl-runtime.BUILD.bazel
@@ -1,3 +1,5 @@
+"Build file for the ROCm-OpenCL-Runtime."
+
 load("@rules_ll//ll:defs.bzl", "ll_library")
 
 ll_library(
@@ -16,7 +18,7 @@ ll_library(
     exposed_hdrs = glob([
         "khronos/headers/opencl2.1/CL/*.h",
         "khronos/headers/opencl2.1/CL/*.hpp",
-    ])
+    ]),
 )
 
 ll_library(
@@ -34,6 +36,7 @@ ll_library(
 # is not needed for hip but we probably want to support native OpenCL toolchains
 # in rules_ll at some point to ease transitioning from OCL to HIP.
 
+# buildifier: disable=no-effect
 '''
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 

--- a/third-party-overlays/rocr.BUILD.bazel
+++ b/third-party-overlays/rocr.BUILD.bazel
@@ -1,3 +1,5 @@
+"Build file for the ROCR-Runtime."
+
 load("@rules_ll//ll:defs.bzl", "ll_library")
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
@@ -85,7 +87,6 @@ ll_library(
     visibility = ["//visibility:public"],
 )
 
-
 ll_library(
     name = "libhsa-runtime64",
     srcs = [
@@ -139,7 +140,6 @@ ll_library(
 
         # TODO: Support the image runtime.
         "src/image/inc/hsa_ext_image_impl.h",
-
         "src/core/common/shared.h",
         "src/core/inc/*.h",
         "src/core/inc/*.hpp",
@@ -150,7 +150,6 @@ ll_library(
         # TODO: At the moment we generate trap_handler_v2.h offline and patch
         # the final header in. Recreate the logic to generate it properly.
         "src/core/runtime/amd_trap_handler_v2.h",
-
         "src/loader/executable.hpp",
         "src/loader/AMDHSAKernelDescriptor.h",
     ]),

--- a/third-party-overlays/roct.BUILD.bazel
+++ b/third-party-overlays/roct.BUILD.bazel
@@ -1,3 +1,5 @@
+"Build file for the ROCT-Thunk-Interface."
+
 load("@rules_ll//ll:defs.bzl", "ll_binary", "ll_library")
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load("@bazel_skylib//rules:native_binary.bzl", "native_binary")


### PR DESCRIPTION
Fixes various issues we had with filedetection previously. Changes pymarkdown to markdownlint. Removes redundant check-yaml hook since we already use yamllint.

Makes all hooks reproducible and enables running via `nix flake check`.

One downside is that the current implementation imports a separate variant of nixpkgs. This will be fixed in a future commit. We also need to remove the old .pre-commit-config.yaml in the next commit.