### PR TITLE
⬆️  Update ROCm-CompilerSUPPORT to 641da67

### DIFF
--- a/ll/init.bzl
+++ b/ll/init.bzl
@@ -85,13 +85,14 @@ def _initialize_rules_ll_impl(_):
     http_archive(
         name = "comgr",
         build_file = "@rules_ll//third-party-overlays:comgr.BUILD.bazel",
-        sha256 = "e76989539fb2454cddb54221bcc81b37c0b429195142a106e592b3e812adc3d8",
-        strip_prefix = "ROCm-CompilerSupport-5650602bbd8df037c0095d46f526e481b262c02c",
+        sha256 = "30f1507ba22debe9293b91536a03026ee3476638379d521ff5fa22bf4701cd56",
+        strip_prefix = "ROCm-CompilerSupport-641da67d59941b8bdf48fc7bed24ec88ce35b103",
         urls = [
-            "https://github.com/RadeonOpenCompute/ROCm-CompilerSupport/archive/5650602bbd8df037c0095d46f526e481b262c02c.zip",
+            "https://github.com/RadeonOpenCompute/ROCm-CompilerSupport/archive/641da67d59941b8bdf48fc7bed24ec88ce35b103.zip",
         ],
         patches = [
             "@rules_ll//patches:comgr_bc2h.diff",
+            "@rules_ll//patches:comgr_fix_version_check.diff",
         ],
         patch_args = ["-p1"],
     )

--- a/patches/comgr_fix_version_check.diff
+++ b/patches/comgr_fix_version_check.diff
@@ -1,0 +1,13 @@
+diff --git a/lib/comgr/include/amd_comgr.h.in b/lib/comgr/include/amd_comgr.h.in
+index eeed72a..196cb40 100644
+--- a/lib/comgr/include/amd_comgr.h.in
++++ b/lib/comgr/include/amd_comgr.h.in
+@@ -51,7 +51,7 @@
+ // Add deprecated support for Comgr on both Windows and Linux
+ // This can be removed in favor of genereic [[deprecated]] in C23
+ #ifndef AMD_COMGR_DEPRECATED
+-#ifdef __GNUC__ && __GNUC__ > 5
++#if defined __GNUC__ && (__GNUC__ > 5 || defined __clang__)
+ #define AMD_COMGR_DEPRECATED(msg) __attribute__((deprecated(msg)))
+ #elif defined(_MSC_VER)
+ //#define AMD_COMGR_DEPRECATED(msg) __declspec(deprecated(msg))


### PR DESCRIPTION
This introduces causes a few new warnings to be raised. These went undetected for a long time and we need to find a way to fix them. Unfortunately the naive approach of switching to non-deprecated symbols didn't work, so we'll have to live with these warnings for a while until fixes are available upstream.