### PR TITLE
Add example for usage of modules with hip

### DIFF
--- a/examples/hip_modules_example/BUILD.bazel
+++ b/examples/hip_modules_example/BUILD.bazel
@@ -1,0 +1,66 @@
+load(
+    "@rules_ll//ll:defs.bzl",
+    "ll_binary",
+    "ll_library",
+)
+
+cc_binary(
+    name = "cc",
+    srcs = ["main.cpp"],
+    copts = [
+        "-v",
+    ],
+    linkopts =
+        [
+            "--verbose",
+        ],
+)
+
+ll_library(
+    name = "hip",
+    srcs = ["hip.cpp"],
+    compilation_mode = "hip_nvptx",
+    compile_flags = [
+        "--std=c++20",
+        "--offload-arch=sm_61",
+        "-Wno-deprecated",
+    ],
+    exposed_hdrs = ["hip.hpp"],
+    visibility = ["@//:__pkg__"],
+)
+
+ll_library(
+    name = "a",
+    compile_flags = ["-std=c++20"],
+    exposed_interfaces = {"a.cppm": "a"},
+)
+
+ll_library(
+    name = "a_wrapper",
+    srcs = ["a_wrapper.cpp"],
+    compile_flags = ["--std=c++20"],
+    exposed_hdrs = ["a_wrapper.hpp"],
+    deps = [":a"],
+)
+
+ll_binary(
+    name = "hip_modules_example",
+    srcs = ["main.cpp"],
+    compilation_mode = "hip_nvptx",
+    compile_flags = [
+        "--std=c++20",
+        "--offload-arch=sm_61",
+        "-Wno-deprecated",
+        "-v",
+        # "--offload-arch=sm_70",
+        # "-Wno-deprecated",
+    ],
+    link_flags = [
+        "-rpath=/usr/lib/wsl/lib",
+    ],
+    visibility = ["@//:__pkg__"],
+    deps = [
+        ":a_wrapper",
+        ":hip",
+    ],
+)

--- a/examples/hip_modules_example/a.cppm
+++ b/examples/hip_modules_example/a.cppm
@@ -1,0 +1,11 @@
+module;
+
+#include <iostream>
+
+export module a;
+
+export namespace a {
+
+auto a() -> void { std::cout << "Hello from module A interface!" << std::endl; }
+
+} // namespace a

--- a/examples/hip_modules_example/a_wrapper.cpp
+++ b/examples/hip_modules_example/a_wrapper.cpp
@@ -1,0 +1,5 @@
+import a;
+
+auto a_wrapper() -> void {
+    a::a();
+}

--- a/examples/hip_modules_example/a_wrapper.hpp
+++ b/examples/hip_modules_example/a_wrapper.hpp
@@ -1,0 +1,6 @@
+#ifndef A_WRAPPER_HPP
+#define A_WRAPPER_HPP
+
+auto a_wrapper() -> void;
+
+#endif  // A_WRAPPER_HPP

--- a/examples/hip_modules_example/hip.cpp
+++ b/examples/hip_modules_example/hip.cpp
@@ -1,0 +1,114 @@
+#include <array>
+#include <iostream>
+#include <vector>
+
+#include "hip/hip_runtime.h"
+
+constexpr float kInputA = 1.0F;
+constexpr float kInputB = 2.0F;
+constexpr float kExpectedOutput = 3.0F;
+constexpr int kDimension = 1 << 20;
+constexpr auto kThreadsPerBlockX = 128;
+constexpr auto kThreadsPerBlockY = 1;
+constexpr auto kThreadsPerBlockZ = 1;
+
+template <typename T>
+constexpr void hip_assert(const T value) {
+  assert((value == hipSuccess));
+}
+
+__global__ auto add_vector(float *input_a, const float *input_b,
+                           const int dimension) -> void {
+  int index = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
+  if (index < dimension) {
+    // NOLINTNEXTLINE cppcoreguidelines-pro-bounds-pointer-arithmetic
+    input_a[index] += input_b[index];
+  }
+}
+
+void print_device_info() {
+  int count = 0;
+  hipError_t err = hipGetDeviceCount(&count);
+  if (err == hipErrorInvalidDevice) {
+    std::cout << "FAIL: invalid device" << std::endl;
+  }
+  std::cout << "Number of devices is " << count << std::endl;
+
+  hipDeviceProp_t device_prop;
+  hip_assert(hipGetDeviceProperties(&device_prop, 0));
+  std::cout << "System major: " << device_prop.major << std::endl;
+  std::cout << "System minor: " << device_prop.minor << std::endl;
+  std::cout << "Device name : ";
+  for (auto character : device_prop.name) {
+    std::cout << character;
+  }
+  std::cout << std::endl;
+}
+
+auto count_errors(const float *result) -> int {
+  int errors = 0;
+  for (int i = 0; i < kDimension; i++) {
+    // NOLINTNEXTLINE cppcoreguidelines-pro-bounds-pointer-arithmetic
+    if (result[i] != kExpectedOutput) {
+      errors++;
+    }
+  }
+
+  if (errors != 0) {
+    std::cout << "Vector calculation failed:" << errors << " errors\n";
+  } else {
+    std::cout << "Vector calculation passed.\n";
+  }
+  return errors;
+}
+
+auto hip_func() -> int {
+  print_device_info();
+
+  float *host_input_a = nullptr;
+  float *host_input_b = nullptr;
+
+  // NOLINTBEGIN cppcoreguidelines-pro-type-reinterpret-cast
+  hip_assert(hipHostMalloc(reinterpret_cast<void **>(&host_input_a),
+                           kDimension * sizeof(float)));
+  hip_assert(hipHostMalloc(reinterpret_cast<void **>(&host_input_b),
+                           kDimension * sizeof(float)));
+  // NOLINTEND cppcoreguidelines-pro-type-reinterpret-cast
+
+  // NOLINTBEGIN cppcoreguidelines-pro-bounds-pointer-arithmetic
+  for (int i = 0; i < kDimension; i++) {
+    host_input_a[i] = kInputA;
+    host_input_b[i] = kInputB;
+  }
+  // NOLINTEND cppcoreguidelines-pro-bounds-pointer-arithmetic
+
+  float *device_input_a = nullptr;
+  float *device_input_b = nullptr;
+
+  hip_assert(hipMalloc(&device_input_a, kDimension * sizeof(float)));
+  hip_assert(hipMalloc(&device_input_b, kDimension * sizeof(float)));
+
+  hip_assert(hipMemcpy(device_input_a, host_input_a, kDimension * sizeof(float),
+                       hipMemcpyHostToDevice));
+  hip_assert(hipMemcpy(device_input_b, host_input_b, kDimension * sizeof(float),
+                       hipMemcpyHostToDevice));
+
+  dim3 grid_dim = dim3(kDimension / kThreadsPerBlockX);
+  dim3 block_dim = dim3(kThreadsPerBlockX);
+
+  hipLaunchKernelGGL(add_vector, grid_dim, block_dim, 0, nullptr,
+                     device_input_a, device_input_b, kDimension);
+
+  hip_assert(hipMemcpy(host_input_a, device_input_a, kDimension * sizeof(float),
+                       hipMemcpyDeviceToHost));
+
+  const int errors = count_errors(host_input_a);
+
+  hip_assert(hipFree(device_input_a));
+  hip_assert(hipFree(device_input_b));
+
+  hip_assert(hipHostFree(host_input_a));
+  hip_assert(hipHostFree(host_input_b));
+
+  return errors;
+}

--- a/examples/hip_modules_example/hip.hpp
+++ b/examples/hip_modules_example/hip.hpp
@@ -1,0 +1,6 @@
+#ifndef HIP_HPP
+#define HIP_HPP
+
+auto hip_func() -> int;
+
+#endif  // HIP_HPP

--- a/examples/hip_modules_example/main.cpp
+++ b/examples/hip_modules_example/main.cpp
@@ -1,0 +1,8 @@
+#include <iostream>
+#include "hip.hpp"
+#include "a_wrapper.hpp"
+
+auto main() -> int {
+    a_wrapper();
+    std::cout << hip_func() << std::endl;
+}


### PR DESCRIPTION
We provide an example how to use modules together with hip code. The trick is to structure the code such that in the targets with modules, we don't need to compile with hip support. 