### PR TITLE
Add shell type to the pre-commit hook

### DIFF
--- a/pre-commit-hooks.nix
+++ b/pre-commit-hooks.nix
@@ -69,6 +69,7 @@
   shellcheck = {
     enable = true;
     excludes = [ "png" ];
+    types_or = [ "shell" ];
   };
 
   # Nix


### PR DESCRIPTION
#54 shellcheck is using "types_or" for its selection of types. By default, "shell" is not included.