### PR TITLE
🧩 Clean up module logic

### DIFF
--- a/docs/reference/providers.md
+++ b/docs/reference/providers.md
@@ -49,4 +49,20 @@ The default provider returned by an `ll_*` target.
 | <a id="LlInfo-exposed_defines"></a>`exposed_defines` |  A <code>depset</code> of defines.    |
 | <a id="LlInfo-exposed_hdrs"></a>`exposed_hdrs` |  A <code>depset</code> of header files.    |
 | <a id="LlInfo-exposed_includes"></a>`exposed_includes` |  A <code>depset</code> of includes.    |
-| <a id="LlInfo-exposed_bmis"></a>`exposed_bmis` |  A <code>depset</code> of BMIs.    |
+| <a id="LlInfo-exposed_bmis"></a>`exposed_bmis` |  A <code>depset</code> of <code>LlModuleInfo</code> providers.    |
+
+
+<a id="LlModuleInfo"></a>
+
+## `LlModuleInfo`
+
+<pre><code>LlModuleInfo(<a href="#LlModuleInfo-module_name">module_name</a>, <a href="#LlModuleInfo-bmi">bmi</a>)</code></pre>
+Provider for a module.
+
+`fields`
+
+
+| Name  | Description |
+| :------------- | :------------- |
+| <a id="LlModuleInfo-module_name"></a>`module_name` |  The name of the module.    |
+| <a id="LlModuleInfo-bmi"></a>`bmi` |  The precompiled module interface.    |

--- a/ll/actions.bzl
+++ b/ll/actions.bzl
@@ -36,6 +36,7 @@ load(
     "link_shared_object_outputs",
     "precompile_interface_outputs",
 )
+load("//ll:providers.bzl", "LlModuleInfo")
 load(
     "//ll:tools.bzl",
     "compile_object_tools",
@@ -67,7 +68,7 @@ def compile_objects(
         A tuple `(out_files, cdfs)`, of output files and compilation database
         fragments.
     """
-    internal_bmi_files = [bmi for bmi, _ in internal_bmis]
+    internal_bmi_files = [interface.bmi for interface in internal_bmis]
     out_files = []
     cdfs = []
 
@@ -191,7 +192,9 @@ def precompile_interfaces(
             angled_includes,
             bmis,
         )
-        internal_bmis.append((file_out, module_name))
+        internal_bmis.append(
+            LlModuleInfo(bmi = file_out, module_name = module_name),
+        )
         cdfs.append(cdf_out)
 
     # Exposed BMIs are available to direct dependents of the target. Internal
@@ -211,7 +214,9 @@ def precompile_interfaces(
                     transitive = [bmis],
                 ),
             )
-            exposed_bmis.append((file_out, module_name))
+            exposed_bmis.append(
+                LlModuleInfo(bmi = file_out, module_name = module_name),
+            )
             cdfs.append(cdf_out)
 
     return internal_bmis, exposed_bmis, cdfs

--- a/ll/inputs.bzl
+++ b/ll/inputs.bzl
@@ -48,7 +48,7 @@ def compile_object_inputs(
     toolchain = ctx.toolchains["//ll:toolchain_type"]
 
     # TODO: This variable name is misleading.
-    interfaces = depset([file for file, _ in interfaces.to_list()])
+    interfaces = depset([interface.bmi for interface in interfaces.to_list()])
 
     direct = (
         [in_file] +

--- a/ll/providers.bzl
+++ b/ll/providers.bzl
@@ -10,7 +10,7 @@ LlInfo = provider(
         "exposed_defines": "A `depset` of defines.",
         "exposed_hdrs": "A `depset` of header files.",
         "exposed_includes": "A `depset` of includes.",
-        "exposed_bmis": "A `depset` of BMIs.",
+        "exposed_bmis": "A `depset` of `LlModuleInfo` providers.",
     },
 )
 
@@ -28,5 +28,13 @@ LlCompilationDatabaseInfo = provider(
 
         This file stores the compilation database.
         """,
+    },
+)
+
+LlModuleInfo = provider(
+    doc = "Provider for a module.",
+    fields = {
+        "module_name": "The name of the module.",
+        "bmi": "The precompiled module interface.",
     },
 )


### PR DESCRIPTION
Adds a new LlModuleInfo provider that supercedes the old manually tracked (bmi, module_name) tuples. This lets us avoid indexes and instead use more readable attributes to reference the bmi and module name.

Includes a bugfix where BMI -> Object compilations for the module stub would wrongly add unused include flags.