### PR TITLE
🚂 Remove transitive includes from libcxx

### DIFF
--- a/ll/BUILD.bazel
+++ b/ll/BUILD.bazel
@@ -106,19 +106,19 @@ ll_toolchain(
     }),
     cpp_abihdrs = select({
         ":bootstrap": None,
-        "//conditions:default": "@llvm-project//libcxxabi:libcxxabi_headers",
+        "//conditions:default": "@llvm-project//libcxxabi:headers",
     }),
     cpp_abilib = select({
         ":bootstrap": None,
-        "//conditions:default": "@llvm-project//libcxxabi:libll_cxxabi",
+        "//conditions:default": "@llvm-project//libcxxabi",
     }),
     cpp_stdhdrs = select({
         ":bootstrap": None,
-        "//conditions:default": "@llvm-project//libcxx:libcxx_headers",
+        "//conditions:default": "@llvm-project//libcxx:headers",
     }),
     cpp_stdlib = select({
         ":bootstrap": None,
-        "//conditions:default": "@llvm-project//libcxx:libll_cxx",
+        "//conditions:default": "@llvm-project//libcxx",
     }),
     exec_compatible_with = [
         "@platforms//os:linux",

--- a/ll/args.bzl
+++ b/ll/args.bzl
@@ -344,6 +344,9 @@ def compile_object_args(
     # Always use experimental libcxx features.
     args.add("-D_LIBCPP_ENABLE_EXPERIMENTAL")
 
+    # Always disable transitive includes for libcxx headers.
+    args.add("-D_LIBCPP_REMOVE_TRANSITIVE_INCLUDES")
+
     # TODO: Module precompilations embed absolute paths in precompiled binaries.
     # We use this workaround to prevent abi_tag attribute redeclaration errors
     # in libcxx/include/__bit_reference. We need to figure out how we can

--- a/ll/init.bzl
+++ b/ll/init.bzl
@@ -71,6 +71,7 @@ def _initialize_rules_ll_impl(_):
             "@rules_ll//patches:hipamd_fix_extraneous_parentheses.diff",
             "@rules_ll//patches:hipamd_default_visibility.diff",
             "@rules_ll//patches:hipamd_enforce_semicolon.diff",
+            "@rules_ll//patches:hipamd_fix_local_address_space.diff",
         ],
         patch_args = ["-p1"],
     )

--- a/llvm-project-overlay/libcxx/BUILD.bazel
+++ b/llvm-project-overlay/libcxx/BUILD.bazel
@@ -50,7 +50,7 @@ expand_template(
 )
 
 filegroup(
-    name = "libcxx_headers",
+    name = "headers",
     srcs = glob(["include/**/*"]) + [
         ":__config_site_gen",
         ":module_modulemap_gen",
@@ -59,13 +59,13 @@ filegroup(
 )
 
 filegroup(
-    name = "libcxx_sources",
+    name = "sources",
     srcs = glob(["src/**/*"]),
     visibility = ["//visibility:public"],
 )
 
 ll_library(
-    name = "libll_cxx",
+    name = "libcxx",
     srcs = [
         "src/algorithm.cpp",
         "src/any.cpp",
@@ -167,6 +167,7 @@ ll_library(
         "_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER",
         "_LIBCPP_LINK_PTHREAD_LIB",
         "_LIBCPP_LINK_RT_LIB",
+        "_LIBCPP_REMOVE_TRANSITIVE_INCLUDES",
         "_LIBCXXABI_BUILDING_LIBRARY",
         "LIBCXX_BUILDING_LIBCXXABI",
     ],
@@ -175,11 +176,11 @@ ll_library(
         "$(GENERATED)/libcxx/include",
     ],
     exposed_hdrs = [
-        "//libcxx:libcxx_headers",
+        "//libcxx:headers",
     ],
     includes = [
         "libcxx/src",
     ],
     visibility = ["//visibility:public"],
-    deps = ["//libcxxabi:libll_cxxabi"],
+    deps = ["//libcxxabi"],
 )

--- a/llvm-project-overlay/libcxxabi/BUILD.bazel
+++ b/llvm-project-overlay/libcxxabi/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@rules_ll//ll:defs.bzl", "ll_library")
 
 filegroup(
-    name = "libcxxabi_headers",
+    name = "headers",
     srcs = [
         "include/__cxxabi_config.h",
         "include/cxxabi.h",
@@ -10,7 +10,7 @@ filegroup(
 )
 
 ll_library(
-    name = "libll_cxxabi",
+    name = "libcxxabi",
     srcs = [
         # C++ABI files
         "src/cxa_aux_runtime.cpp",
@@ -74,8 +74,8 @@ ll_library(
         "-fvisibility-inlines-hidden",
     ],
     data = [
-        "//libcxx:libcxx_headers",
-        "//libcxx:libcxx_sources",
+        "//libcxx:headers",
+        "//libcxx:sources",
     ],
     defines = [
         "LIBCXX_BUILDING_LIBCXXABI",
@@ -86,7 +86,7 @@ ll_library(
         "_LIBCXXABI_LINK_PTHREAD_LIB",
     ],
     exposed_angled_includes = ["libcxxabi/include"],
-    exposed_hdrs = [":libcxxabi_headers"],
+    exposed_hdrs = [":headers"],
     includes = [
         "libcxx/src",
     ],

--- a/patches/hipamd_fix_local_address_space.diff
+++ b/patches/hipamd_fix_local_address_space.diff
@@ -1,0 +1,17 @@
+diff --git a/include/hip/amd_detail/device_library_decls.h b/include/hip/amd_detail/device_library_decls.h
+index 02228705..55817c8a 100644
+--- a/include/hip/amd_detail/device_library_decls.h
++++ b/include/hip/amd_detail/device_library_decls.h
+@@ -118,10 +118,10 @@ extern "C" __device__ uint64_t __ockl_fprintf_append_string_n(uint64_t msg_desc,
+                                                               uint64_t length, uint32_t is_last);
+ 
+ // Introduce local address space
+-#define __local __attribute__((address_space(3)))
++#define __device_local __attribute__((address_space(3)))
+ 
+ #ifdef __HIP_DEVICE_COMPILE__
+-__device__ inline static __local void* __to_local(unsigned x) { return (__local void*)x; }
++__device__ inline static __device_local void* __to_local(unsigned x) { return (__device_local void*)x; }
+ #endif //__HIP_DEVICE_COMPILE__
+ 
+ // Using hip.amdgcn.bc - sync threads

--- a/patches/rules_ll_overlay_patch.diff
+++ b/patches/rules_ll_overlay_patch.diff
@@ -1270,10 +1270,10 @@ index 000000000000..8ad56ad46df6
 +)
 diff --git a/utils/bazel/llvm-project-overlay/libcxx/BUILD.bazel b/utils/bazel/llvm-project-overlay/libcxx/BUILD.bazel
 new file mode 100644
-index 000000000000..0b89f41b95fa
+index 000000000000..c1b167e454c6
 --- /dev/null
 +++ b/utils/bazel/llvm-project-overlay/libcxx/BUILD.bazel
-@@ -0,0 +1,185 @@
+@@ -0,0 +1,186 @@
 +load("@rules_ll//ll:defs.bzl", "ll_library")
 +load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
 +
@@ -1326,7 +1326,7 @@ index 000000000000..0b89f41b95fa
 +)
 +
 +filegroup(
-+    name = "libcxx_headers",
++    name = "headers",
 +    srcs = glob(["include/**/*"]) + [
 +        ":__config_site_gen",
 +        ":module_modulemap_gen",
@@ -1335,13 +1335,13 @@ index 000000000000..0b89f41b95fa
 +)
 +
 +filegroup(
-+    name = "libcxx_sources",
++    name = "sources",
 +    srcs = glob(["src/**/*"]),
 +    visibility = ["//visibility:public"],
 +)
 +
 +ll_library(
-+    name = "libll_cxx",
++    name = "libcxx",
 +    srcs = [
 +        "src/algorithm.cpp",
 +        "src/any.cpp",
@@ -1443,6 +1443,7 @@ index 000000000000..0b89f41b95fa
 +        "_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER",
 +        "_LIBCPP_LINK_PTHREAD_LIB",
 +        "_LIBCPP_LINK_RT_LIB",
++        "_LIBCPP_REMOVE_TRANSITIVE_INCLUDES",
 +        "_LIBCXXABI_BUILDING_LIBRARY",
 +        "LIBCXX_BUILDING_LIBCXXABI",
 +    ],
@@ -1451,24 +1452,24 @@ index 000000000000..0b89f41b95fa
 +        "$(GENERATED)/libcxx/include",
 +    ],
 +    exposed_hdrs = [
-+        "//libcxx:libcxx_headers",
++        "//libcxx:headers",
 +    ],
 +    includes = [
 +        "libcxx/src",
 +    ],
 +    visibility = ["//visibility:public"],
-+    deps = ["//libcxxabi:libll_cxxabi"],
++    deps = ["//libcxxabi"],
 +)
 diff --git a/utils/bazel/llvm-project-overlay/libcxxabi/BUILD.bazel b/utils/bazel/llvm-project-overlay/libcxxabi/BUILD.bazel
 new file mode 100644
-index 000000000000..ca55184b2de5
+index 000000000000..6cbc3f815b89
 --- /dev/null
 +++ b/utils/bazel/llvm-project-overlay/libcxxabi/BUILD.bazel
 @@ -0,0 +1,94 @@
 +load("@rules_ll//ll:defs.bzl", "ll_library")
 +
 +filegroup(
-+    name = "libcxxabi_headers",
++    name = "headers",
 +    srcs = [
 +        "include/__cxxabi_config.h",
 +        "include/cxxabi.h",
@@ -1477,7 +1478,7 @@ index 000000000000..ca55184b2de5
 +)
 +
 +ll_library(
-+    name = "libll_cxxabi",
++    name = "libcxxabi",
 +    srcs = [
 +        # C++ABI files
 +        "src/cxa_aux_runtime.cpp",
@@ -1541,8 +1542,8 @@ index 000000000000..ca55184b2de5
 +        "-fvisibility-inlines-hidden",
 +    ],
 +    data = [
-+        "//libcxx:libcxx_headers",
-+        "//libcxx:libcxx_sources",
++        "//libcxx:headers",
++        "//libcxx:sources",
 +    ],
 +    defines = [
 +        "LIBCXX_BUILDING_LIBCXXABI",
@@ -1553,7 +1554,7 @@ index 000000000000..ca55184b2de5
 +        "_LIBCXXABI_LINK_PTHREAD_LIB",
 +    ],
 +    exposed_angled_includes = ["libcxxabi/include"],
-+    exposed_hdrs = [":libcxxabi_headers"],
++    exposed_hdrs = [":headers"],
 +    includes = [
 +        "libcxx/src",
 +    ],


### PR DESCRIPTION
Unify names to be more concise as we do with other external dependencies. Enable _LIBCPP_REMOVE_TRANSITIVE_INCLUDES since this will soon become default behavior upstream.