### PR TITLE
🎨 Rename libcxx targets

### DIFF
--- a/ll/BUILD.bazel
+++ b/ll/BUILD.bazel
@@ -106,19 +106,19 @@ ll_toolchain(
     }),
     cpp_abihdrs = select({
         ":bootstrap": None,
-        "//conditions:default": "@llvm-project//libcxxabi:libcxxabi_headers",
+        "//conditions:default": "@llvm-project//libcxxabi:headers",
     }),
     cpp_abilib = select({
         ":bootstrap": None,
-        "//conditions:default": "@llvm-project//libcxxabi:libll_cxxabi",
+        "//conditions:default": "@llvm-project//libcxxabi",
     }),
     cpp_stdhdrs = select({
         ":bootstrap": None,
-        "//conditions:default": "@llvm-project//libcxx:libcxx_headers",
+        "//conditions:default": "@llvm-project//libcxx:headers",
     }),
     cpp_stdlib = select({
         ":bootstrap": None,
-        "//conditions:default": "@llvm-project//libcxx:libll_cxx",
+        "//conditions:default": "@llvm-project//libcxx",
     }),
     exec_compatible_with = [
         "@platforms//os:linux",

--- a/llvm-project-overlay/libcxx/BUILD.bazel
+++ b/llvm-project-overlay/libcxx/BUILD.bazel
@@ -50,7 +50,7 @@ expand_template(
 )
 
 filegroup(
-    name = "libcxx_headers",
+    name = "headers",
     srcs = glob(["include/**/*"]) + [
         ":__config_site_gen",
         ":module_modulemap_gen",
@@ -59,13 +59,13 @@ filegroup(
 )
 
 filegroup(
-    name = "libcxx_sources",
+    name = "sources",
     srcs = glob(["src/**/*"]),
     visibility = ["//visibility:public"],
 )
 
 ll_library(
-    name = "libll_cxx",
+    name = "libcxx",
     srcs = [
         "src/algorithm.cpp",
         "src/any.cpp",
@@ -176,11 +176,11 @@ ll_library(
         "$(GENERATED)/libcxx/include",
     ],
     exposed_hdrs = [
-        "//libcxx:libcxx_headers",
+        "//libcxx:headers",
     ],
     includes = [
         "libcxx/src",
     ],
     visibility = ["//visibility:public"],
-    deps = ["//libcxxabi:libll_cxxabi"],
+    deps = ["//libcxxabi"],
 )

--- a/llvm-project-overlay/libcxxabi/BUILD.bazel
+++ b/llvm-project-overlay/libcxxabi/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@rules_ll//ll:defs.bzl", "ll_library")
 
 filegroup(
-    name = "libcxxabi_headers",
+    name = "headers",
     srcs = [
         "include/__cxxabi_config.h",
         "include/cxxabi.h",
@@ -10,7 +10,7 @@ filegroup(
 )
 
 ll_library(
-    name = "libll_cxxabi",
+    name = "libcxxabi",
     srcs = [
         # C++ABI files
         "src/cxa_aux_runtime.cpp",
@@ -74,8 +74,8 @@ ll_library(
         "-fvisibility-inlines-hidden",
     ],
     data = [
-        "//libcxx:libcxx_headers",
-        "//libcxx:libcxx_sources",
+        "//libcxx:headers",
+        "//libcxx:sources",
     ],
     defines = [
         "LIBCXX_BUILDING_LIBCXXABI",
@@ -86,7 +86,7 @@ ll_library(
         "_LIBCXXABI_LINK_PTHREAD_LIB",
     ],
     exposed_angled_includes = ["libcxxabi/include"],
-    exposed_hdrs = [":libcxxabi_headers"],
+    exposed_hdrs = [":headers"],
     includes = [
         "libcxx/src",
     ],

--- a/patches/rules_ll_overlay_patch.diff
+++ b/patches/rules_ll_overlay_patch.diff
@@ -1270,7 +1270,7 @@ index 000000000000..8ad56ad46df6
 +)
 diff --git a/utils/bazel/llvm-project-overlay/libcxx/BUILD.bazel b/utils/bazel/llvm-project-overlay/libcxx/BUILD.bazel
 new file mode 100644
-index 000000000000..3ca2a451193b
+index 000000000000..c1b167e454c6
 --- /dev/null
 +++ b/utils/bazel/llvm-project-overlay/libcxx/BUILD.bazel
 @@ -0,0 +1,186 @@
@@ -1326,7 +1326,7 @@ index 000000000000..3ca2a451193b
 +)
 +
 +filegroup(
-+    name = "libcxx_headers",
++    name = "headers",
 +    srcs = glob(["include/**/*"]) + [
 +        ":__config_site_gen",
 +        ":module_modulemap_gen",
@@ -1335,13 +1335,13 @@ index 000000000000..3ca2a451193b
 +)
 +
 +filegroup(
-+    name = "libcxx_sources",
++    name = "sources",
 +    srcs = glob(["src/**/*"]),
 +    visibility = ["//visibility:public"],
 +)
 +
 +ll_library(
-+    name = "libll_cxx",
++    name = "libcxx",
 +    srcs = [
 +        "src/algorithm.cpp",
 +        "src/any.cpp",
@@ -1452,24 +1452,24 @@ index 000000000000..3ca2a451193b
 +        "$(GENERATED)/libcxx/include",
 +    ],
 +    exposed_hdrs = [
-+        "//libcxx:libcxx_headers",
++        "//libcxx:headers",
 +    ],
 +    includes = [
 +        "libcxx/src",
 +    ],
 +    visibility = ["//visibility:public"],
-+    deps = ["//libcxxabi:libll_cxxabi"],
++    deps = ["//libcxxabi"],
 +)
 diff --git a/utils/bazel/llvm-project-overlay/libcxxabi/BUILD.bazel b/utils/bazel/llvm-project-overlay/libcxxabi/BUILD.bazel
 new file mode 100644
-index 000000000000..ca55184b2de5
+index 000000000000..6cbc3f815b89
 --- /dev/null
 +++ b/utils/bazel/llvm-project-overlay/libcxxabi/BUILD.bazel
 @@ -0,0 +1,94 @@
 +load("@rules_ll//ll:defs.bzl", "ll_library")
 +
 +filegroup(
-+    name = "libcxxabi_headers",
++    name = "headers",
 +    srcs = [
 +        "include/__cxxabi_config.h",
 +        "include/cxxabi.h",
@@ -1478,7 +1478,7 @@ index 000000000000..ca55184b2de5
 +)
 +
 +ll_library(
-+    name = "libll_cxxabi",
++    name = "libcxxabi",
 +    srcs = [
 +        # C++ABI files
 +        "src/cxa_aux_runtime.cpp",
@@ -1542,8 +1542,8 @@ index 000000000000..ca55184b2de5
 +        "-fvisibility-inlines-hidden",
 +    ],
 +    data = [
-+        "//libcxx:libcxx_headers",
-+        "//libcxx:libcxx_sources",
++        "//libcxx:headers",
++        "//libcxx:sources",
 +    ],
 +    defines = [
 +        "LIBCXX_BUILDING_LIBCXXABI",
@@ -1554,7 +1554,7 @@ index 000000000000..ca55184b2de5
 +        "_LIBCXXABI_LINK_PTHREAD_LIB",
 +    ],
 +    exposed_angled_includes = ["libcxxabi/include"],
-+    exposed_hdrs = [":libcxxabi_headers"],
++    exposed_hdrs = [":headers"],
 +    includes = [
 +        "libcxx/src",
 +    ],


### PR DESCRIPTION
This is more concise and in line with other external dependencies.