### PR TITLE
👒 Add libcxxabi headers to RBE toolchain

### DIFF
--- a/bazel-wrapper/default.nix
+++ b/bazel-wrapper/default.nix
@@ -74,6 +74,7 @@ BAZEL_CXXOPTS=${pkgs.lib.concatStringsSep ":" [
   "-nostdinc++"
   "-nostdlib++"
   "-isystem${pkgs.llvmPackages_16.libcxx.dev}/include/c++/v1"
+  "-isystem${pkgs.llvmPackages_16.libcxxabi.dev}/include/c++/v1"
 ]}
 
 # TODO: This somehow works without explicitly adding glibc to the library search

--- a/rbe/default/cc/BUILD
+++ b/rbe/default/cc/BUILD
@@ -96,6 +96,7 @@ cc_toolchain_config(
         "/nix/store/9bldnbh7kcxyq8y0g1bifd5ywz7m3bq9-glibc-2.37-8-dev/include",
         "/nix/store/whzffqb6y92zwfdvxzplyh9z4ry0hjc5-clang-wrapper-16.0.6/resource-root/share",
         "/nix/store/qp7k02y44y1rfp7c79vp6rgilmh65687-libcxx-16.0.6-dev/include/c++/v1",
+        "/nix/store/sr1nvxp5q5qsj0njxgy0p1j5r7rair9d-libcxxabi-16.0.6-dev/include/c++/v1",
     ],
     cxx_flags = [
         "-std=c++17",
@@ -103,6 +104,7 @@ cc_toolchain_config(
         "-nostdinc++",
         "-nostdlib++",
         "-isystem/nix/store/qp7k02y44y1rfp7c79vp6rgilmh65687-libcxx-16.0.6-dev/include/c++/v1",
+        "-isystem/nix/store/sr1nvxp5q5qsj0njxgy0p1j5r7rair9d-libcxxabi-16.0.6-dev/include/c++/v1",
     ],
     dbg_compile_flags = ["-g"],
     host_system_name = "x86_64-unknown-linux-gnu",

--- a/rbe/default/cc/builtin_include_directory_paths
+++ b/rbe/default/cc/builtin_include_directory_paths
@@ -8,3 +8,4 @@ declared action inputs or the action commandline changes.
 /nix/store/9bldnbh7kcxyq8y0g1bifd5ywz7m3bq9-glibc-2.37-8-dev/include
 /nix/store/whzffqb6y92zwfdvxzplyh9z4ry0hjc5-clang-wrapper-16.0.6/resource-root/share
 /nix/store/qp7k02y44y1rfp7c79vp6rgilmh65687-libcxx-16.0.6-dev/include/c++/v1
+/nix/store/sr1nvxp5q5qsj0njxgy0p1j5r7rair9d-libcxxabi-16.0.6-dev/include/c++/v1

--- a/rbe/default/cc/module.modulemap
+++ b/rbe/default/cc/module.modulemap
@@ -2499,4 +2499,6 @@ module "crosstool" [system] {
   textual header "/nix/store/qp7k02y44y1rfp7c79vp6rgilmh65687-libcxx-16.0.6-dev/include/c++/v1/version"
   textual header "/nix/store/qp7k02y44y1rfp7c79vp6rgilmh65687-libcxx-16.0.6-dev/include/c++/v1/wchar.h"
   textual header "/nix/store/qp7k02y44y1rfp7c79vp6rgilmh65687-libcxx-16.0.6-dev/include/c++/v1/wctype.h"
+  textual header "/nix/store/sr1nvxp5q5qsj0njxgy0p1j5r7rair9d-libcxxabi-16.0.6-dev/include/c++/v1/__cxxabi_config.h"
+  textual header "/nix/store/sr1nvxp5q5qsj0njxgy0p1j5r7rair9d-libcxxabi-16.0.6-dev/include/c++/v1/cxxabi.h"
 }

--- a/rbe/default/config/BUILD
+++ b/rbe/default/config/BUILD
@@ -40,7 +40,7 @@ platform(
         "@bazel_tools//tools/cpp:clang",
     ],
     exec_properties = {
-        "container-image": "docker://localhost:5000/rules_ll@sha256:a36fc090ced7831cc2c60f9a6158fb821cbf98885297154d8ed2ae62424568dc",
+        "container-image": "docker://localhost:5000/rules_ll@sha256:01d7e3a0428ef22ec672608ea2201f2dff5545a6ba2c1803c17398198550e9c5",
         "OSFamily": "Linux",
     },
     parents = ["@local_config_platform//:host"],


### PR DESCRIPTION
Usually just having this available for linking is fine, but some projects, for instance Abseil explicitly depend on these headers.