### PR TITLE
🌊 Modernize GHA workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,26 +13,26 @@ permissions: read-all
 
 jobs:
   CodeQL-Build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       security-events: write
     steps:
-      - name: "Checkout code"
-        uses: >- # v3.5.2
-          actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+      - name: Checkout
+        uses: >- # v4.1.1
+          actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: >- # v2.3.6
-          github/codeql-action/init@83f0fe6c4988d98a455712a27f0255212bba9bd4
+        uses: >- # v2.17.0
+          github/codeql-action/init@99c9897648dded3fe63d6f328c46089dd57735ca
         with:
           languages: go
 
       - name: Autobuild
-        uses: >- # v2.3.6
-          github/codeql-action/autobuild@83f0fe6c4988d98a455712a27f0255212bba9bd4
+        uses: >- # v2.17.0
+          github/codeql-action/autobuild@99c9897648dded3fe63d6f328c46089dd57735ca
 
       - name: Perform CodeQL Analysis
-        uses: >- # v2.3.6
-          github/codeql-action/analyze@83f0fe6c4988d98a455712a27f0255212bba9bd4
+        uses: >- # v2.17.0
+          github/codeql-action/analyze@99c9897648dded3fe63d6f328c46089dd57735ca

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,15 +9,38 @@ permissions: read-all
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       contents: write
     steps:
-      - uses: >- # v3.5.2
-          actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
-      - uses: >- # v4.6.1
-          actions/setup-python@bd6b4b6205c4dbad673328db7b31b7fab9e241c0
+      - name: Checkout
+        uses: >- # v4.1.1
+          actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+
+      - name: Configure Git Credentials
+        run: "\
+          git config user.name \
+            github-actions[bot] \n
+          git config user.email \
+            41898282+github-actions[bot]@users.noreply.github.com"
+
+      - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
+
+      - name: Cache artifacts
+        uses: >- # v4.0.2
+          actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        with:
+          key: mkdocs-material-${{ env.cache_id }}
+          path: .cache
+          restore-keys: |
+            mkdocs-material-
+
+      - uses: >- # v5.1.0
+          actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d
         with:
           python-version: 3.x
-      - run: pip install mkdocs-material==9.1.15
+      - run: "\
+          pip install \
+            mkdocs==1.5.3 \
+            mkdocs-material==9.5.15"
       - run: mkdocs gh-deploy --force

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -12,27 +12,22 @@ permissions: read-all
 
 jobs:
   pre-commit-checks:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: >- # v3.5.2
-          actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+        uses: >- # v4.1.1
+          actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+
       - name: Install Nix
-        uses: >- # v21
-          cachix/install-nix-action@4b933aa7ebcc94a6174cf1364864e957b4910265
+        uses: >- # v10
+          DeterminateSystems/nix-installer-action@de22e16c4711fca50c816cc9081563429d1cf563
         with:
-          nix_path: nixpkgs=channel:nixos-unstable
-      - name: Cache Nix artifacts
-        uses: >- # v3.3.1
-          actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
-        with:
-          key: "${{ runner.os }}-nix-${{
-            hashfiles('flake.lock', 'flake.nix', 'pre-commit.nix') }}"
-          path: ~/nix
-          restore-keys: |
-            ${{ runner.os }}-nix-${{
-              hashfiles('flake.lock', 'flake.nix', 'pre-commit.nix') }}
-            ${{ runner.os }}-nix-
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cache Nix derivations
+        uses: >- # v4
+          DeterminateSystems/magic-nix-cache-action@fc6aaceb40b9845a02b91e059ec147e78d1b4e41
+
       - name: Run pre-commit hooks
         run: |
-          nix --store ~/nix flake check --impure -L
+          nix flake check --impure -L

--- a/templates/default/.github/workflows/pre-commit.yml
+++ b/templates/default/.github/workflows/pre-commit.yml
@@ -7,26 +7,27 @@ name: pre-commit
   push:
     branches:
       - main
+
+permissions: read-all
+
 jobs:
   pre-commit-checks:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: >- # v4.1.1
+          actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+
       - name: Install Nix
-        uses: cachix/install-nix-action@v20
+        uses: >- # v10
+          DeterminateSystems/nix-installer-action@de22e16c4711fca50c816cc9081563429d1cf563
         with:
-          nix_path: nixpkgs=channel:nixos-unstable
-      - name: Cache Nix artifacts
-        uses: actions/cache@v3.3.1
-        with:
-          key: "${{ runner.os }}-nix-${{
-            hashfiles('flake.lock', 'flake.nix', 'pre-commit.nix') }}"
-          path: ~/nix
-          restore-keys: |
-            ${{ runner.os }}-nix-${{
-              hashfiles('flake.lock', 'flake.nix', 'pre-commit.nix') }}
-            ${{ runner.os }}-nix-
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cache Nix derivations
+        uses: >- # v4
+          DeterminateSystems/magic-nix-cache-action@fc6aaceb40b9845a02b91e059ec147e78d1b4e41
+
       - name: Run pre-commit hooks
         run: |
-          nix --store ~/nix flake check -L
+          nix flake check --impure -L


### PR DESCRIPTION
Bump all actions, pin the Ubuntu version, migrate to the determinate-nix-installer actions for pre-commit and introduce doc caching and bot signing for doc releases.