### PR TITLE
🫥 Add missing CUDA headers to builtins

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -34,13 +34,14 @@ llvm_project_overlay = use_extension(
     "llvm_project_overlay",
 )
 llvm_project_overlay.configure(
-    commit = "fa8fda85c6792d9078922ab8658c321c4939e63a",
+    commit = "41574f5a6e2d961f398d3c671c34ac3c8e417464",
     patches = [
         "@rules_ll//patches:mallinfo2_patch.diff",
         "@rules_ll//patches:rules_ll_overlay_patch.diff",
         "@rules_ll//patches:llvm-project-fix-zlib-includes.diff",
+        "@rules_ll//patches:llvm-add-missing-cuda-cmath-header.diff",
     ],
-    sha256 = "109d4c7c29b986183342988ed3842bd6a0325f7818d16f355b56b42fc2b80777",
+    sha256 = "da9a908ea6b158de5986ac1b40444a08a7329bd81e0940875413f1193c24ce5d",
     targets = [
         "AMDGPU",
         "NVPTX",

--- a/patches/llvm-add-missing-cuda-cmath-header.diff
+++ b/patches/llvm-add-missing-cuda-cmath-header.diff
@@ -1,0 +1,13 @@
+diff --git a/utils/bazel/llvm-project-overlay/clang/BUILD.bazel b/utils/bazel/llvm-project-overlay/clang/BUILD.bazel
+index 725ac6bb3812..e84f859a9dd8 100644
+--- a/utils/bazel/llvm-project-overlay/clang/BUILD.bazel
++++ b/utils/bazel/llvm-project-overlay/clang/BUILD.bazel
+@@ -1778,6 +1778,8 @@ builtin_headers = glob(
+     "lib/Headers/module.modulemap",
+     "lib/Headers/riscv_vector.h",
+     "lib/Headers/cuda_wrappers/algorithm",
++    "lib/Headers/cuda_wrappers/bits/basic_string.tcc",
++    "lib/Headers/cuda_wrappers/cmath",
+     "lib/Headers/cuda_wrappers/complex",
+     "lib/Headers/cuda_wrappers/new",
+     "lib/Headers/openmp_wrappers/cmath",


### PR DESCRIPTION
Also bumps LLVM to 41574f5.