### PR TITLE
🌟 Clean up stardoc imports

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -13,10 +13,8 @@ bazel_dep(name = "rules_cc", version = "0.0.17")
 # Various utility functions such as path manipulations and templating.
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 
-# Documentation. These should be dev_dependencies, but that doesn't work at the
-# moment. This is a bug.
-bazel_dep(name = "rules_java", version = "7.6.1", dev_dependency = False)
-bazel_dep(name = "stardoc", version = "0.7.2", dev_dependency = False)
+# Documentation.
+bazel_dep(name = "stardoc", version = "0.7.2", dev_dependency = True)
 
 # TODO(aaronmondal): We don't actually use this. Fix LRE upstream to make this
 #                    import optional.


### PR DESCRIPTION
With Bazel 8 we can finally remove our hacky workarounds.